### PR TITLE
security: Correções de Segurança e Revisão de Rotas da API

### DIFF
--- a/brunofragadev-hml/src/main/java/com/brunofragadev/BrunofragadevApplication.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/BrunofragadevApplication.java
@@ -1,13 +1,17 @@
 package com.brunofragadev;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class BrunofragadevApplication {
 
+	private static final Logger log = LoggerFactory.getLogger(BrunofragadevApplication.class);
+
 	public static void main(String[] args) {
 		SpringApplication.run(BrunofragadevApplication.class, args);
-        System.out.println("Servidor inicializado com sucesso!");
+		log.info("Servidor inicializado com sucesso!");
 	}
 }

--- a/brunofragadev-hml/src/main/java/com/brunofragadev/infrastructure/config/SecurityConfig.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/infrastructure/config/SecurityConfig.java
@@ -5,10 +5,13 @@ import com.brunofragadev.infrastructure.security.SecurityFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -30,9 +33,11 @@ public class SecurityConfig {
     @Autowired
     SecurityFilter securityFilter;
 
+    @Autowired
+    Environment environment;
+
     //ROTAS PUBLICAS
     private static final String[] PUBLIC_ENDPOINTS = {
-            "/api/auth/cliente-login",
             "/auth/login",
             "/auth/login/google",
             "/v3/api-docs/**",
@@ -45,6 +50,7 @@ public class SecurityConfig {
             "/usuario/senha/recuperacao/validar-codigo",
             "/usuario/senha/recuperacao/alterar-senha",
             "/projetos/publicos",
+            "/projetos/publicos/**",
             "/feedback/geral/listar-todos",
             "/feedback/projetos/listar-todos/**",
             "/feedback/artigos/listar-todos/**",
@@ -52,10 +58,6 @@ public class SecurityConfig {
             "/geral/artigos/listar-todos-publicados",
             "/geral/artigos/listar-ultimos-publicados",
             "/geral/artigos/{slug}",
-            "/h2-console/**" //usado localmente apenas para testes
-
-
-            //>>>>>>>>>>>>>LIBERADO PUBLICAMENTE PARA TESTES APENAS<<<<<<<<<<<
     };
     //ROTAS PROTEGIDAS
     private static final Map<String, Role> PROTECTED_ROUTES = Map.ofEntries(
@@ -88,7 +90,6 @@ public class SecurityConfig {
             entry("/paineladm/projetos", Role.ADMIN3),
             entry("/paineladm/projetos/**", Role.ADMIN3),
             entry("/paineladm/artigos/**", Role.ADMIN3),
-            entry("/paineladm/atualizar/{id}", Role.ADMIN3),
             entry("/paineladm/logs/**", Role.ADMIN3)
     );
 
@@ -96,13 +97,16 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .csrf(csrf -> csrf.disable())
+                .csrf(AbstractHttpConfigurer::disable)
                 .headers(headers -> headers
-                        .frameOptions(frameOptions -> frameOptions.sameOrigin())
+                        .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> {
                     authorize.requestMatchers(PUBLIC_ENDPOINTS).permitAll();
+                    if (Arrays.asList(environment.getActiveProfiles()).contains("local")) {
+                        authorize.requestMatchers("/h2-console/**").permitAll();
+                    }
                     PROTECTED_ROUTES.forEach((url, role) -> {
                         authorize.requestMatchers(url).hasRole(role.name());
                     });
@@ -114,7 +118,11 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedOriginPatterns(List.of(
+                "https://www.brunofragadev.com",
+                "http://localhost:5173",
+                "http://localhost:3000"
+        ));
         configuration.setAllowCredentials(true);
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));

--- a/brunofragadev-hml/src/main/java/com/brunofragadev/infrastructure/email/BrevoEmailProvider.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/infrastructure/email/BrevoEmailProvider.java
@@ -1,5 +1,7 @@
 package com.brunofragadev.infrastructure.email;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -10,6 +12,8 @@ import java.util.Map;
 
 @Component
 public class BrevoEmailProvider implements EmailProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(BrevoEmailProvider.class);
 
     private final WebClient webClient;
 
@@ -41,6 +45,6 @@ public class BrevoEmailProvider implements EmailProvider {
                 .toBodilessEntity()
                 .block();
 
-        System.out.println("E-mail enviado via Brevo para: " + para);
+        log.info("E-mail enviado via Brevo para: {}", para);
     }
 }

--- a/brunofragadev-hml/src/main/java/com/brunofragadev/infrastructure/handler/GlobalAsyncErrorHandler.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/infrastructure/handler/GlobalAsyncErrorHandler.java
@@ -2,6 +2,8 @@ package com.brunofragadev.infrastructure.handler;
 
 
 import com.brunofragadev.infrastructure.log.application.usecase.CreateNewErrorLogUseCase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.stereotype.Component;
 
@@ -9,6 +11,8 @@ import java.lang.reflect.Method;
 
 @Component
 public class GlobalAsyncErrorHandler implements AsyncUncaughtExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalAsyncErrorHandler.class);
 
     private final CreateNewErrorLogUseCase createNewErrorLogUseCase;
 
@@ -18,8 +22,7 @@ public class GlobalAsyncErrorHandler implements AsyncUncaughtExceptionHandler {
 
     @Override
     public void handleUncaughtException(Throwable ex, Method method, Object... params) {
-        System.err.println("Falha no método: " + method.getName());
-        ex.printStackTrace();
+        log.error("Falha no método assíncrono: {}", method.getName(), ex);
         createNewErrorLogUseCase.execute(
                 (Exception) ex,
                 method.getDeclaringClass().getSimpleName() + "." + method.getName(),

--- a/brunofragadev-hml/src/main/java/com/brunofragadev/infrastructure/log/api/controller/LogController.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/infrastructure/log/api/controller/LogController.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@CrossOrigin(origins = "*")
 @RestController
 @RequestMapping("/paineladm/logs")
 @SecurityRequirement(name = "bearerAuth")

--- a/brunofragadev-hml/src/main/java/com/brunofragadev/infrastructure/log/api/dto/response/ErrorLogResponse.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/infrastructure/log/api/dto/response/ErrorLogResponse.java
@@ -8,6 +8,5 @@ public record ErrorLogResponse(
         String endpoint,
         String metodoHttp,
         String mensagemResumo,
-        String stackTraceCompleta,
         String usuarioLogado
 ) {}

--- a/brunofragadev-hml/src/main/java/com/brunofragadev/infrastructure/log/application/mapper/ErrorLogMapper.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/infrastructure/log/application/mapper/ErrorLogMapper.java
@@ -15,7 +15,6 @@ public class ErrorLogMapper {
                 log.getEndpoint(),
                 log.getMetodoHttp(),
                 log.getMensagemResumo(),
-                log.getStackTraceCompleta(),
                 log.getUsuarioLogado()
         );
     }

--- a/brunofragadev-hml/src/main/java/com/brunofragadev/module/article/api/controller/GeneralArticleController.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/module/article/api/controller/GeneralArticleController.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@CrossOrigin(origins = "*")
 @RestController
 @RequestMapping("/geral/artigos")
 @Tag(name = "Artigos - Público", description = "Endpoints acessíveis para leitura e listagem de artigos publicados")

--- a/brunofragadev-hml/src/main/java/com/brunofragadev/module/article/api/controller/PrivateArticleController.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/module/article/api/controller/PrivateArticleController.java
@@ -16,7 +16,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@CrossOrigin(origins = "*")
 @RestController
 @RequestMapping("/paineladm/artigos")
 @SecurityRequirement(name = "bearerAuth")

--- a/brunofragadev-hml/src/main/java/com/brunofragadev/module/auth/api/controller/AuthController.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/module/auth/api/controller/AuthController.java
@@ -13,7 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-@CrossOrigin(origins = "*")
 @RestController
 @RequestMapping("/auth")
 @Tag(name = "Autenticação", description = "Endpoints para login e validação de tokens")

--- a/brunofragadev-hml/src/main/java/com/brunofragadev/module/feedback/api/controller/ArticleFeedbackController.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/module/feedback/api/controller/ArticleFeedbackController.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@CrossOrigin(origins = "*")
 @RestController
 @RequestMapping("/feedback/artigos") // 👈 Endereço específico para Artigos
 @SecurityRequirement(name = "bearerAuth")

--- a/brunofragadev-hml/src/main/java/com/brunofragadev/module/feedback/api/controller/GeneralFeedbackController.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/module/feedback/api/controller/GeneralFeedbackController.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@CrossOrigin(origins = "*")
 @RestController
 @RequestMapping("/feedback/geral")
 @SecurityRequirement(name = "bearerAuth")

--- a/brunofragadev-hml/src/main/java/com/brunofragadev/module/feedback/api/controller/ProjectFeedbackController.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/module/feedback/api/controller/ProjectFeedbackController.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@CrossOrigin(origins = "*")
 @RestController
 @RequestMapping("/feedback/projetos")
 @SecurityRequirement(name = "bearerAuth")

--- a/brunofragadev-hml/src/main/java/com/brunofragadev/module/project/api/controller/PrivateProjectController.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/module/project/api/controller/PrivateProjectController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@CrossOrigin("*")
 @RestController
 @RequestMapping("/paineladm/projetos")
 @Validated

--- a/brunofragadev-hml/src/main/java/com/brunofragadev/module/project/api/controller/PublicProjectController.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/module/project/api/controller/PublicProjectController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@CrossOrigin("*")
 @RestController
 @RequestMapping("/projetos/publicos")
 @Tag(name = "Portfólio Público", description = "Endpoints abertos para exibição dos projetos no site (Não exige Token)")

--- a/brunofragadev-hml/src/main/java/com/brunofragadev/module/user/api/controller/UserController.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/module/user/api/controller/UserController.java
@@ -16,6 +16,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -23,7 +25,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@CrossOrigin("*")
 @RestController
 @RequestMapping("/usuario")
 @Validated
@@ -99,14 +100,14 @@ public class UserController {
 
     @PostMapping("/reenviar-codigo")
     @Operation(summary = "Reenviar código de ativação", description = "Gera e envia um novo código de 6 dígitos para o e-mail do usuário.")
-    public ResponseEntity<Void> resendCode(@RequestBody String userName) {
+    public ResponseEntity<Void> resendCode(@RequestBody @NotBlank @Size(max = 150) String userName) {
         generateVerificationCodeUseCase.execute(userName);
         return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/senha/recuperacao")
     @Operation(summary = "Solicitar recuperação de senha", description = "Envia um e-mail com instruções e código para recuperar a senha esquecida.")
-    public ResponseEntity<ApiResponse<PasswordRecoveryResponse>> recoverPassword(@RequestBody String userNameOrEmail) {
+    public ResponseEntity<ApiResponse<PasswordRecoveryResponse>> recoverPassword(@RequestBody @NotBlank @Size(max = 150) String userNameOrEmail) {
         PasswordRecoveryResponse emailDTO = sendPasswordRecoveryEmailUseCase.execute(userNameOrEmail);
         return ResponseEntity.ok(ApiResponse.success("Email enviado com sucesso", emailDTO));
     }

--- a/brunofragadev-hml/src/main/resources/application.properties
+++ b/brunofragadev-hml/src/main/resources/application.properties
@@ -19,18 +19,18 @@ springdoc.api-docs.path=/v3/api-docs
 # Escanear pacotes do project
 springdoc.packages-to-scan=com.brunofragadev
 
-google.client.id=${GOOGLE_CLIENT_ID:123123123123}
+google.client.id=${GOOGLE_CLIENT_ID}
 
-# JTW CONFIG
-jwt.secret.key=${JWT_SECRET_KEY:SuaChaveJWTSuperLongaESeguraGeradaEmBase64ParaTestesLocais123456789}
+# JWT CONFIG
+jwt.secret.key=${JWT_SECRET_KEY}
 jwt.expiration.ms=3600000
 
 #Banco de Dados PostgreSQL
-spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:5432/nome_do_seu_banco}
-spring.datasource.username=${DB_USERNAME:brunofdev}
-spring.datasource.password=${DB_PASSWORD:123321123321123321}
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 #BREVO
-brevo.api.key=${BREVO_API_KEY:sua_chave_de_testes_aqui}
-brevo.sender.email=${BREVO_SENDER_EMAIL:brunofragaa97@gmail.com}
+brevo.api.key=${BREVO_API_KEY}
+brevo.sender.email=${BREVO_SENDER_EMAIL}


### PR DESCRIPTION
## Visão Geral

Esta PR consolida um conjunto de correções de segurança identificadas durante uma auditoria completa da API. As mudanças eliminam vulnerabilidades reais que poderiam comprometer o ambiente de produção, melhoram a qualidade do código e garantem que o mapeamento de rotas no `SecurityConfig` esteja correto e sem brechas.

---

## Problemas Corrigidos

### Segurança Crítica

#### CORS com wildcard em produção
A configuração anterior utilizava `setAllowedOriginPatterns(List.of("*"))` combinada com `setAllowCredentials(true)`, o que viola a especificação CORS e representa um risco real de exploração. As origens agora são explícitas e restritas:

- `https://www.brunofragadev.com` (produção)
- `http://localhost:5173` e `http://localhost:3000` (desenvolvimento local)

#### H2 Console exposto publicamente
O endpoint `/h2-console/**` estava configurado como público (`permitAll()`), permitindo acesso direto ao banco de dados em produção sem qualquer autenticação. A correção libera o console **somente quando o perfil `local` estiver ativo**, bloqueando completamente o acesso em produção via verificação de `Environment`.

#### Valores sensíveis com fallback inseguro
As variáveis de ambiente no `application.properties` possuíam valores padrão hardcoded (chaves JWT fracas, credenciais de banco, chaves de API). A aplicação agora **falha explicitamente na inicialização** caso alguma variável obrigatória não esteja configurada, eliminando o risco de subir em produção com credenciais de teste.

#### Stack trace exposto na API de logs
O campo `stackTraceCompleta` estava sendo retornado no DTO de resposta do endpoint de logs (`/paineladm/logs`), expondo detalhes internos da aplicação para qualquer cliente autenticado. O campo foi removido do DTO e do mapper, permanecendo apenas na entidade para persistência interna.

---

### Revisão e Correção de Rotas

#### Rota pública faltando: detalhes de projeto
O endpoint `GET /projetos/publicos/{id}` não estava coberto pelos endpoints públicos — apenas `/projetos/publicos` (lista) estava configurado. Isso fazia com que o endpoint de detalhes exigisse `ADMIN3`, tornando-o inacessível para visitantes do portfólio. Corrigido adicionando `/projetos/publicos/**`.

#### Rota morta nos endpoints públicos
A rota `/api/auth/cliente-login` estava declarada nos endpoints públicos, mas não possui nenhum controller mapeado. Removida para evitar configurações enganosas.

#### Rota protegida obsoleta
A entrada `/paineladm/atualizar/{id}` estava no mapa de rotas protegidas sem corresponder a nenhum endpoint real nos controllers. Removida.

---

### Qualidade de Código

#### @CrossOrigin removido de todos os controllers
A anotação `@CrossOrigin("*")` estava declarada nos 10 controllers além da configuração global no `SecurityConfig`, gerando duplicidade e risco. O controle de CORS agora é centralizado exclusivamente no `SecurityConfig`.

**Controllers ajustados:**
`AuthController`, `UserController`, `GeneralArticleController`, `PrivateArticleController`, `PublicProjectController`, `PrivateProjectController`, `GeneralFeedbackController`, `ProjectFeedbackController`, `ArticleFeedbackController`, `LogController`

#### Migração de System.out/err para SLF4J Logger
Múltiplos `System.out.println()` e `System.err.println()` foram substituídos pelo padrão correto com `LoggerFactory`, tornando os logs rastreáveis, configuráveis por nível e compatíveis com ferramentas de observabilidade.

**Arquivos ajustados:**
- `BrunofragadevApplication` — log de inicialização
- `BrevoEmailProvider` — confirmação de envio de e-mail
- `GlobalAsyncErrorHandler` — erro em método assíncrono (com stack trace via `log.error`)

#### Validação nos endpoints de recuperação de senha
Os endpoints `POST /usuario/reenviar-codigo` e `POST /usuario/senha/recuperacao` recebiam `String` puro no body sem nenhuma validação de entrada. Adicionadas as constraints `@NotBlank` e `@Size(max = 150)` aproveitando o `@Validated` já presente no controller.

---

## Arquivos Modificados

| Arquivo | Tipo de Alteração |
|---|---|
| `SecurityConfig.java` | CORS, H2 Console por perfil, rotas públicas/protegidas |
| `application.properties` | Remoção de valores default inseguros |
| `ErrorLogResponse.java` | Remoção do campo `stackTraceCompleta` |
| `ErrorLogMapper.java` | Ajuste para novo contrato do DTO |
| `BrunofragadevApplication.java` | System.out → Logger |
| `BrevoEmailProvider.java` | System.out → Logger |
| `GlobalAsyncErrorHandler.java` | System.err → Logger |
| `UserController.java` | @CrossOrigin removido + @NotBlank/@Size adicionados |
| 9 controllers restantes | @CrossOrigin removido |

---

## O que não foi alterado

- Lógica de negócio e use cases
- Configuração JWT (será revisada separadamente)
- Testes (ainda em desenvolvimento)
- `application-local.properties` (arquivo local, não versionado)

---

## Checklist

- [x] CORS restrito às origens corretas
- [x] H2 Console bloqueado em produção
- [x] Sem credenciais hardcoded no código versionado
- [x] Stack trace não exposto na API
- [x] Todas as rotas públicas verificadas e corrigidas
- [x] @CrossOrigin centralizado no SecurityConfig
- [x] Logs padronizados com SLF4J
- [x] Validação de entrada nos endpoints de recuperação de senha
- [x] Testado localmente com perfil `local`