### PR TITLE
feat: configuração de deploy no Render com controle de Swagger e iframe

### DIFF
--- a/brunofragadev-hml/.gitignore
+++ b/brunofragadev-hml/.gitignore
@@ -31,3 +31,8 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Credenciais e configurações locais ###
+**/application-local.properties
+.env
+.env.*

--- a/brunofragadev-hml/Dockerfile
+++ b/brunofragadev-hml/Dockerfile
@@ -9,5 +9,6 @@ RUN mvn clean package -DskipTests
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
+ENV SWAGGER_ENABLED=true
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/brunofragadev-hml/src/main/java/com/brunofragadev/infrastructure/config/SecurityConfig.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/infrastructure/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.brunofragadev.infrastructure.config;
 import com.brunofragadev.module.user.domain.entity.Role;
 import com.brunofragadev.infrastructure.security.SecurityFilter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -35,6 +36,9 @@ public class SecurityConfig {
 
     @Autowired
     Environment environment;
+
+    @Value("${SWAGGER_ENABLED:false}")
+    private boolean swaggerEnabled;
 
     //ROTAS PUBLICAS
     private static final String[] PUBLIC_ENDPOINTS = {
@@ -98,9 +102,16 @@ public class SecurityConfig {
         return httpSecurity
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
-                .headers(headers -> headers
-                        .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
-                )
+                .headers(headers -> {
+                    if (swaggerEnabled) {
+                        headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable)
+                               .contentSecurityPolicy(csp -> csp.policyDirectives(
+                                       "frame-ancestors 'self' https://brunofragadev.com http://localhost:5173 http://localhost:5174"
+                               ));
+                    } else {
+                        headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin);
+                    }
+                })
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> {
                     authorize.requestMatchers(PUBLIC_ENDPOINTS).permitAll();

--- a/brunofragadev-hml/src/main/resources/application.properties
+++ b/brunofragadev-hml/src/main/resources/application.properties
@@ -8,7 +8,8 @@ spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=true
 
 # habilitar Swagger UI
-springdoc.swagger-ui.enabled=true
+springdoc.swagger-ui.enabled=${SWAGGER_ENABLED:false}
+springdoc.api-docs.enabled=${SWAGGER_ENABLED:false}
 
 # definir o caminho do Swagger UI
 springdoc.swagger-ui.path=/swagger-ui.html


### PR DESCRIPTION
## O que foi feito

Preparação completa da API para deploy no Render, com controle granular de visibilidade do Swagger e permissão de iframe por ambiente — sem impactar a API em produção no Azure.

---

## Motivação

A API possui dois ambientes distintos:
- **Azure (produção real):** Swagger deve permanecer **bloqueado** — a API está exposta publicamente via `brunofragadev.com` e não deve ter documentação acessível por qualquer visitante
- **Render (novo ambiente):** Swagger deve estar **habilitado** — será embedado via iframe no portfólio para fins de demonstração técnica
- **Local:** Swagger habilitado para desenvolvimento e testes

O controle precisava ser feito por variável de ambiente, pois o deploy no Render é feito via repositório Git + Dockerfile.

---

## Alterações

### `Dockerfile`
- Adicionado `ENV SWAGGER_ENABLED=true` no estágio de runtime
- Garante que qualquer container buildado a partir deste Dockerfile terá o Swagger habilitado automaticamente, sem precisar de configuração manual no painel do Render

### `application.properties`
- `springdoc.swagger-ui.enabled` alterado de `true` fixo para `${SWAGGER_ENABLED:false}`
- Adicionado `springdoc.api-docs.enabled=${SWAGGER_ENABLED:false}`
- O padrão agora é **false** — ambientes sem a variável têm Swagger bloqueado por padrão (protege o Azure)

### `SecurityConfig.java`
- Injetado `@Value("${SWAGGER_ENABLED:false}")` para leitura da variável de ambiente
- Controle de iframe via CSP `frame-ancestors` quando Swagger está ativo:
  - `SWAGGER_ENABLED=true` → desabilita X-Frame-Options e aplica `frame-ancestors 'self' https://brunofragadev.com http://localhost:5173 http://localhost:5174`
  - `SWAGGER_ENABLED=false` → mantém `frameOptions(sameOrigin)` — comportamento restritivo original

### `.gitignore`
- Adicionada seção de proteção de credenciais locais:
  - `**/application-local.properties` — arquivo com credenciais reais de desenvolvimento nunca será commitado
  - `.env` e `.env.*` — arquivos de variáveis de ambiente protegidos por padrão

---

## Comportamento por ambiente

| Ambiente | `SWAGGER_ENABLED` | Swagger | Iframe |
|---|---|---|---|
| Azure (produção) | não definida → `false` | Bloqueado | `sameOrigin` — bloqueado |
| Render | `true` via Dockerfile | Habilitado | Liberado para `brunofragadev.com` |
| Local | `true` via `application-local.properties` | Habilitado | Liberado para `localhost:5173/5174` |

---

## O que não foi alterado
- Nenhuma rota de negócio foi modificada
- A lógica de autenticação permanece intacta
- A configuração de CORS não foi alterada
- A API em produção no Azure não é afetada por estas mudanças