### PR TITLE
fix: adicionar www.brunofragadev.com no CSP frame-ancestors

### DIFF
--- a/brunofragadev-hml/src/main/java/com/brunofragadev/infrastructure/config/SecurityConfig.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/infrastructure/config/SecurityConfig.java
@@ -106,7 +106,7 @@ public class SecurityConfig {
                     if (swaggerEnabled) {
                         headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable)
                                .contentSecurityPolicy(csp -> csp.policyDirectives(
-                                       "frame-ancestors 'self' https://brunofragadev.com http://localhost:5173 http://localhost:5174"
+                                       "frame-ancestors 'self' https://brunofragadev.com https://www.brunofragadev.com http://localhost:5173 http://localhost:5174"
                                ));
                     } else {
                         headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin);


### PR DESCRIPTION
## O que mudou

Adicionado `https://www.brunofragadev.com` na diretiva CSP `frame-ancestors` do `SecurityConfig.java`.

**Antes:**
```
frame-ancestors 'self' https://brunofragadev.com http://localhost:5173 http://localhost:5174
```

**Depois:**
```
frame-ancestors 'self' https://brunofragadev.com https://www.brunofragadev.com http://localhost:5173 http://localhost:5174
```

## Motivo

O portfólio pode ser acessado tanto via `brunofragadev.com` quanto via `www.brunofragadev.com`. Sem o `www`, o iframe do Swagger era bloqueado pelo browser quando o visitante acessava pela versão com subdomínio.