### PR TITLE
fix: corrigir ordem de registro dos filtros de segurança

### DIFF
--- a/brunofragadev-hml/src/main/java/com/brunofragadev/infrastructure/config/SecurityConfig.java
+++ b/brunofragadev-hml/src/main/java/com/brunofragadev/infrastructure/config/SecurityConfig.java
@@ -127,8 +127,8 @@ public class SecurityConfig {
                     });
                     authorize.anyRequest().hasRole("ADMIN3");
                 })
-                .addFilterBefore(rateLimitFilter, SecurityFilter.class)
                 .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(rateLimitFilter, SecurityFilter.class)
                 .build();
     }
     @Bean


### PR DESCRIPTION
## Problema

Após a PR #38 (rate limiting), a API no Azure passou a retornar **503 Service Unavailable** em todas as requisições, impedindo o carregamento do portfolio.

**Causa raiz:** No Spring Security 6, `addFilterBefore(filterA, ClasseB)` exige que `ClasseB` já esteja registrado no comparador interno. Como `SecurityFilter` é um filtro customizado, ele só é registrado após a chamada `.addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)`.

A ordem original era:
```java
.addFilterBefore(rateLimitFilter, SecurityFilter.class)      // ❌ SecurityFilter ainda desconhecido
.addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)
```

Isso lançava `IllegalArgumentException` na inicialização → Spring context não subia → Azure retornava 503 em todas as requisições.

## Correção

Invertida a ordem das chamadas para que `SecurityFilter` seja registrado primeiro:

```java
.addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)  // registra SecurityFilter
.addFilterBefore(rateLimitFilter, SecurityFilter.class)                        // agora é válido
```

A cadeia resultante permanece correta: `RateLimitFilter → SecurityFilter → UsernamePasswordAuthenticationFilter`

## Impacto

- Sem alteração de comportamento em runtime
- Apenas corrige a falha de inicialização que derrubava a aplicação no Azure